### PR TITLE
Prevent adding or subtracting non-money objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add @vested/money
 ```js
 import { Money } from '@vested/money'
 
-const oneFifty = new Money(150, 'USD')
+const oneFifty = Money.fromCents(150, 'USD')
 // => $1.50
 
 const threeDollars = oneFifty.times(2)
@@ -45,12 +45,16 @@ fourDollars.eq(twoDollars.plus(twoDollars))
 
 ## Methods
 
-### new Money(cents, currency = 'USD'): Money
+### new Money(cents, currency = 'USD): Money
+### Money.fromCents(cents, currency = 'USD'): Money
 
 Builds a new Money object, taking the smallest unit (cents) as the first argument and an optional currency string as a second argument (default 'USD'). For example, the following builds a $3.50 USD Money object:
 
 ```js
 const money = new Money(350, 'USD')
+// => 3.50
+
+const money2 = Money.fromCents(350, 'USD')
 // => 3.50
 ```
 
@@ -93,7 +97,7 @@ const money = Money.zero('USD')
 Returns a Big object representing the cents of the Money object
 
 ```js
-const money = new Money(3.50, 'EUR')
+const money = Money.fromCents(3.50, 'EUR')
 money.cents
 // => '350'
 ```
@@ -113,7 +117,7 @@ money.currency
 Returns a Big object representing the units of the Money object
 
 ```js
-const money = new Money(350, 'EUR')
+const money = Money.fromCents(350, 'EUR')
 money.units
 // => '3.50'
 ```
@@ -246,7 +250,7 @@ If a Money object of a different currency is provided, a `CurrencyMismatchError`
 const money = Money.fromAmount('3.50')
 money.eq('350')
 // => true
-money.eq(new Money('350'))
+money.eq(Money.fromCents('350'))
 // => true
 money.eq(175)
 // => false
@@ -262,7 +266,7 @@ If a Money object of a different currency is provided, a `CurrencyMismatchError`
 const money = Money.fromAmount('3.50')
 money.gt('175')
 // => true
-money.gt(new Money('350'))
+money.gt(Money.fromCents('350'))
 // => false
 money.gt('350')
 // => false
@@ -278,7 +282,7 @@ If a Money object of a different currency is provided, a `CurrencyMismatchError`
 const money = Money.fromAmount('3.50')
 money.lt('500')
 // => true
-money.lt(new Money('350'))
+money.lt(Money.fromCents('350'))
 // => false
 money.lt('350')
 // => false

--- a/lib/Money.ts
+++ b/lib/Money.ts
@@ -59,28 +59,20 @@ export class Money {
     return Money.fromCents(this.cents.round(0, roundingMode(mode)), this.currency)
   }
 
-  plus (other: Biggable | Money): Money {
-    if (other instanceof Money) {
-      if (other.currency !== this.currency) {
-        throw new CurrencyMismatchError()
-      }
-
-      return this.plus(other.cents)
+  plus (other: Money): Money {
+    if (other.currency !== this.currency) {
+      throw new CurrencyMismatchError()
     }
 
-    return Money.fromCents(this.cents.plus(other), this.currency)
+    return Money.fromCents(this.cents.plus(other.cents), this.currency)
   }
 
-  minus (other: Biggable | Money): Money {
-    if (other instanceof Money) {
-      if (other.currency !== this.currency) {
-        throw new CurrencyMismatchError()
-      }
-
-      return this.minus(other.cents)
+  minus (other: Money): Money {
+    if (other.currency !== this.currency) {
+      throw new CurrencyMismatchError()
     }
 
-    return Money.fromCents(this.cents.minus(other), this.currency)
+    return Money.fromCents(this.cents.minus(other.cents), this.currency)
   }
 
   times (other: Biggable | Money): Money {

--- a/lib/Money.ts
+++ b/lib/Money.ts
@@ -15,21 +15,25 @@ export class Money {
     this.currency = currency
   }
 
+  static fromCents (cents: Biggable, currency = 'USD'): Money {
+    return new this(cents, currency)
+  }
+
   static fromAmount (amount: Biggable, currency = 'USD'): Money {
     if (isString(amount)) {
       amount = amount.replace(/,/, '')
     }
 
     const dollars = new Big(amount)
-    return new Money(dollars.times(100), currency)
+    return Money.fromCents(dollars.times(100), currency)
   }
 
   static fromJSON (json: MoneyJSON): Money {
-    return new Money(json.cents, json.currency)
+    return Money.fromCents(json.cents, json.currency)
   }
 
   static zero (currency = 'USD'): Money {
-    return new Money(0, currency)
+    return Money.fromCents(0, currency)
   }
 
   get units (): Big {
@@ -52,7 +56,7 @@ export class Money {
   }
 
   roundToCent (mode: RoundingMode = 'half-up'): Money {
-    return new Money(this.cents.round(0, roundingMode(mode)), this.currency)
+    return Money.fromCents(this.cents.round(0, roundingMode(mode)), this.currency)
   }
 
   plus (other: Biggable | Money): Money {
@@ -64,7 +68,7 @@ export class Money {
       return this.plus(other.cents)
     }
 
-    return new Money(this.cents.plus(other), this.currency)
+    return Money.fromCents(this.cents.plus(other), this.currency)
   }
 
   minus (other: Biggable | Money): Money {
@@ -76,7 +80,7 @@ export class Money {
       return this.minus(other.cents)
     }
 
-    return new Money(this.cents.minus(other), this.currency)
+    return Money.fromCents(this.cents.minus(other), this.currency)
   }
 
   times (other: Biggable | Money): Money {
@@ -88,7 +92,7 @@ export class Money {
       return this.times(other.units)
     }
 
-    return new Money(this.cents.times(other), this.currency)
+    return Money.fromCents(this.cents.times(other), this.currency)
   }
 
   div (other: Biggable | Money): Money {
@@ -100,7 +104,7 @@ export class Money {
       return this.div(other.units)
     }
 
-    return new Money(this.cents.div(other), this.currency)
+    return Money.fromCents(this.cents.div(other), this.currency)
   }
 
   eq (other: Biggable | Money): boolean {

--- a/test/Money.spec.ts
+++ b/test/Money.spec.ts
@@ -21,6 +21,26 @@ describe('Money.constructor', () => {
   })
 })
 
+describe('Money.fromCents', () => {
+  it('casts cents to a Big', () => {
+    const money = Money.fromCents(200, 'USD')
+    expect(money.cents).toBeInstanceOf(Big)
+  })
+
+  it('defaults to USD as the currency', () => {
+    const money = Money.fromCents(100)
+
+    expect(money.currency).toBe('USD')
+  })
+
+  it('throws if given invalid cents', () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      Money.fromCents('WRONG')
+    }).toThrow()
+  })
+})
+
 describe('Money.fromAmount()', () => {
   it('converts whole dollars to cents', () => {
     const money = Money.fromAmount(200, 'USD')
@@ -98,12 +118,12 @@ describe('Money.prototype.toJSON()', () => {
 
 describe('Money.prototype.toFixed()', () => {
   it('returns a string of the units to a given 2 decimal places by default', () => {
-    const money = new Money('12345', 'EUR')
+    const money = Money.fromCents('12345', 'EUR')
     expect(money.toFixed()).toEqual('123.45')
   })
 
   it('gives a string to any specified decimal places', () => {
-    const money = new Money('12345', 'EUR')
+    const money = Money.fromCents('12345', 'EUR')
     expect(money.toFixed(3)).toEqual('123.450')
   })
 })
@@ -184,21 +204,21 @@ describe('Money.prototype.roundToCent()', () => {
 
 describe('Money.prototype.minus', () => {
   it('subtracts two Money objects', () => {
-    const money = new Money('1234', 'USD')
-    const other = new Money('1230', 'USD')
+    const money = Money.fromCents('1234', 'USD')
+    const other = Money.fromCents('1230', 'USD')
 
-    expect(money.minus(other)).toEqual(new Money(4, 'USD'))
+    expect(money.minus(other)).toEqual(Money.fromCents(4, 'USD'))
   })
 
   it('subtracts cents from the current cents', () => {
-    const money = new Money('1234', 'USD')
+    const money = Money.fromCents('1234', 'USD')
 
-    expect(money.minus('30')).toEqual(new Money(1204, 'USD'))
+    expect(money.minus('30')).toEqual(Money.fromCents(1204, 'USD'))
   })
 
   it('throws if subtracting a different currency', () => {
-    const money = new Money('1234', 'USD')
-    const other = new Money('1234', 'EUR')
+    const money = Money.fromCents('1234', 'USD')
+    const other = Money.fromCents('1234', 'EUR')
 
     expect(() => {
       money.minus(other)
@@ -208,21 +228,21 @@ describe('Money.prototype.minus', () => {
 
 describe('Money.prototype.times', () => {
   it('multiplies two Money objects', () => {
-    const money = new Money('400', 'USD')
-    const other = new Money('200', 'USD')
+    const money = Money.fromCents('400', 'USD')
+    const other = Money.fromCents('200', 'USD')
 
-    expect(money.times(other)).toEqual(new Money('800', 'USD'))
+    expect(money.times(other)).toEqual(Money.fromCents('800', 'USD'))
   })
 
   it('multiplies the current unit by the other number', () => {
-    const money = new Money('300', 'USD')
+    const money = Money.fromCents('300', 'USD')
 
-    expect(money.times('2')).toEqual(new Money(600, 'USD'))
+    expect(money.times('2')).toEqual(Money.fromCents(600, 'USD'))
   })
 
   it('throws if multiplying a different currency', () => {
-    const money = new Money('1234', 'USD')
-    const other = new Money('1234', 'EUR')
+    const money = Money.fromCents('1234', 'USD')
+    const other = Money.fromCents('1234', 'EUR')
 
     expect(() => {
       money.times(other)

--- a/test/Money.spec.ts
+++ b/test/Money.spec.ts
@@ -202,18 +202,30 @@ describe('Money.prototype.roundToCent()', () => {
   })
 })
 
+describe('Money.prototype.plus', () => {
+  it('adds two Money objects', () => {
+    const money = Money.fromCents('200', 'USD')
+    const other = Money.fromCents('300', 'USD')
+
+    expect(money.plus(other)).toEqual(Money.fromCents(500, 'USD'))
+  })
+
+  it('throws if adding a different currency', () => {
+    const money = Money.fromCents('1234', 'USD')
+    const other = Money.fromCents('1234', 'EUR')
+
+    expect(() => {
+      money.plus(other)
+    }).toThrow(CurrencyMismatchError)
+  })
+})
+
 describe('Money.prototype.minus', () => {
   it('subtracts two Money objects', () => {
     const money = Money.fromCents('1234', 'USD')
     const other = Money.fromCents('1230', 'USD')
 
     expect(money.minus(other)).toEqual(Money.fromCents(4, 'USD'))
-  })
-
-  it('subtracts cents from the current cents', () => {
-    const money = Money.fromCents('1234', 'USD')
-
-    expect(money.minus('30')).toEqual(Money.fromCents(1204, 'USD'))
   })
 
   it('throws if subtracting a different currency', () => {


### PR DESCRIPTION
It was not clear what `money.add('5')` would do -- would it add 5 cents or $5.00.  This removes the ambiguity.