### PR TITLE
Only allow multiplying and dividing by a Big-like type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,6 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": ["error", {
       "functions": false
     }],
-    "@typescript-eslint/strict-boolean-expressions": "warn"
+    "@typescript-eslint/strict-boolean-expressions": "off"
   }
 };

--- a/README.md
+++ b/README.md
@@ -221,9 +221,7 @@ money.minus(money2)
 
 ### money.times(other): Money
 
-Returns a new Money object by multiplying the other value. The argument can be another Money object, a string, a number, or a Big.
-
-If a Money object of a different currency is provided, a `CurrencyMismatchError` will be thrown.
+Returns a new Money object by multiplying the other value. The argument can be a string, a number, or a Big.
 
 ```js
 const money = Money.fromAmount('3.50')
@@ -233,9 +231,7 @@ money.times('2')
 
 ### money.div(other): Money
 
-Returns a new Money object by dividing by the other value. The argument can be another Money object, a string, a number, or a Big.
-
-If a Money object of a different currency is provided, a `CurrencyMismatchError` will be thrown.
+Returns a new Money object by dividing by the other value. The argument can be a string, a number, or a Big.
 
 ```js
 const money = Money.fromAmount('3.50')

--- a/lib/Money.ts
+++ b/lib/Money.ts
@@ -17,6 +17,8 @@ export class Money {
 
     this.units = new Big(units)
     this.currency = currency
+
+    Object.freeze(this)
   }
 
   static fromCents (cents: Biggable, currency = 'USD'): Money {

--- a/lib/Money.ts
+++ b/lib/Money.ts
@@ -46,6 +46,10 @@ export class Money {
     return this.units.times(100)
   }
 
+  toString (): string {
+    return `${this.units.toFixed(2)} ${this.currency}`
+  }
+
   toJSON (): MoneyJSON {
     return {
       units: this.toFixed(),

--- a/lib/Money.ts
+++ b/lib/Money.ts
@@ -86,27 +86,11 @@ export class Money {
     return Money.fromAmount(this.units.minus(other.units), this.currency)
   }
 
-  times (other: Biggable | Money): Money {
-    if (other instanceof Money) {
-      if (other.currency !== this.currency) {
-        throw new CurrencyMismatchError()
-      }
-
-      return this.times(other.units)
-    }
-
+  times (other: Biggable): Money {
     return Money.fromAmount(this.units.times(other), this.currency)
   }
 
-  div (other: Biggable | Money): Money {
-    if (other instanceof Money) {
-      if (other.currency !== this.currency) {
-        throw new CurrencyMismatchError()
-      }
-
-      return this.div(other.units)
-    }
-
+  div (other: Biggable): Money {
     return Money.fromAmount(this.units.div(other), this.currency)
   }
 

--- a/test/Money.spec.ts
+++ b/test/Money.spec.ts
@@ -269,50 +269,18 @@ describe('Money.prototype.minus', () => {
 })
 
 describe('Money.prototype.times', () => {
-  it('multiplies two Money objects', () => {
-    const money = Money.fromCents('400', 'USD')
-    const other = Money.fromCents('200', 'USD')
-
-    expect(money.times(other)).toEqual(Money.fromCents('800', 'USD'))
-  })
-
-  it('multiplies the current unit by the other number', () => {
+  it('multiplies the current units by the other number', () => {
     const money = Money.fromCents('300', 'USD')
 
     expect(money.times('2')).toEqual(Money.fromCents(600, 'USD'))
   })
-
-  it('throws if multiplying a different currency', () => {
-    const money = Money.fromCents('1234', 'USD')
-    const other = Money.fromCents('1234', 'EUR')
-
-    expect(() => {
-      money.times(other)
-    }).toThrow(CurrencyMismatchError)
-  })
 })
 
 describe('Money.prototype.div', () => {
-  it('divides two Money objects', () => {
-    const money = Money.fromCents('300', 'USD')
-    const other = Money.fromCents('200', 'USD')
-
-    expect(money.div(other)).toEqual(Money.fromCents('150', 'USD'))
-  })
-
-  it('divides the current unit by the other number', () => {
+  it('divides the current units by the other number', () => {
     const money = Money.fromCents('300', 'USD')
 
     expect(money.div('2')).toEqual(Money.fromCents(150, 'USD'))
-  })
-
-  it('throws if dividing a different currency', () => {
-    const money = Money.fromCents('1234', 'USD')
-    const other = Money.fromCents('1234', 'EUR')
-
-    expect(() => {
-      money.div(other)
-    }).toThrow(CurrencyMismatchError)
   })
 })
 

--- a/test/Money.spec.ts
+++ b/test/Money.spec.ts
@@ -127,6 +127,14 @@ describe('Money.zero()', () => {
   })
 })
 
+describe('Money.prototype.toString()', () => {
+  it('returns a string representation of the Money object', () => {
+    const money = Money.fromAmount('12.34', 'EUR')
+
+    expect(money.toString()).toEqual('12.34 EUR')
+  })
+})
+
 describe('Money.prototype.toJSON()', () => {
   it('returns a JSON represneation of the money object', () => {
     const money = Money.fromAmount('20', 'EUR')


### PR DESCRIPTION
* [BREAKING] Remove the confusing ability of multiplying or dividing two dollar amounts.  
* [IMPROVEMENT] Prevent modifying a Money object once built
* [IMPROVEMENT] Add `Money.prototype.toString()` so it doesn't print out `[Object object]` 